### PR TITLE
update requirements for vyper to vyper-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY * /layint/
 COPY li_utils/* /layint/li_utils/
 RUN apk update && \
     apk add gcc musl-dev && \
-    pip install layint-runtime-api && \
     pip install -r /layint/requirements.txt
 
 ### Set environment variables for your installation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Now any libraries you install with pip will be local to this environment, access
 From this source directory, run
 
 ```
-pip install layint-runtime-api
 pip install -r requirements.txt
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
-vyper
+vyper-config >= 0.2.1
+layint-runtime-api >= 0.9.6


### PR DESCRIPTION
 - add layint-runtime-api to requirements vs. separate step