### PR TITLE
runtime-api-example-python#21: Fix default policy name

### DIFF
--- a/li_create_default_policy
+++ b/li_create_default_policy
@@ -29,7 +29,7 @@ policy = layint_runtime_api.Policy()
 if args.name:
     policy.name = args.name
 else:
-    policy.name = "Default policy"
+    policy.name = "Default Policy"
 policy.description = "Default policy blocks nothing."
 policy.default_file_action = "allow"
 policy.default_network_action = "allow"


### PR DESCRIPTION
Fixes https://github.com/LayeredInsight/runtime-api-example-python/issues/21 
In apiserver, "Default Policy" name is used for creating and using default policy, fix that in the python script.

Tested creating default policy and config